### PR TITLE
Update to allow platform to enable/disable SMMUs

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -177,10 +177,12 @@ UpdateMapping (
   // invalidate all SMMU's TLB for a given virtual address, just the one that was updated.
   if (!Valid) {
     for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-      Status = SmmuV3TLBInvalidateAddress (&mIoMmu->SmmuInfo[SmmuIndex], VirtualAddress);
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB\n", __func__));
-        goto End;
+      if (mIoMmu->SmmuInfo[SmmuIndex].Enabled) {
+        Status = SmmuV3TLBInvalidateAddress (&mIoMmu->SmmuInfo[SmmuIndex], VirtualAddress);
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "%a: Failed to invalidate TLB\n", __func__));
+          goto End;
+        }
       }
     }
   }
@@ -306,7 +308,9 @@ IoMmuMap (
 End:
   // Only prints errors if Event Queue is not empty and GError != 0
   for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-    SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
+    if (mIoMmu->SmmuInfo[SmmuIndex].Enabled) {
+      SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
+    }
   }
 
   ASSERT_EFI_ERROR (Status);
@@ -357,7 +361,9 @@ IoMmuUnmap (
 End:
   // Only prints errors if Event Queue is not empty and GError != 0
   for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-    SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
+    if (mIoMmu->SmmuInfo[SmmuIndex].Enabled) {
+      SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
+    }
   }
 
   ASSERT_EFI_ERROR (Status);
@@ -509,7 +515,9 @@ IoMmuSetAttribute (
 End:
   // Only prints errors if Event Queue is not empty and GError != 0
   for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
-    SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
+    if (mIoMmu->SmmuInfo[SmmuIndex].Enabled) {
+      SmmuV3LogErrors (&mIoMmu->SmmuInfo[SmmuIndex]);
+    }
   }
 
   ASSERT_EFI_ERROR (Status);

--- a/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuDxe.c
@@ -1035,6 +1035,7 @@ InitializeSmmuDxe (
   EFI_STATUS               Status;
   EFI_EVENT                Event;
   UINT32                   SmmuIndex;
+  UINT32                   SmmuStatusIndex;
   EFI_ACPI_TABLE_PROTOCOL  *AcpiTable;
   SMMU_CONFIG              *SmmuConfig;
   PAGE_TABLE               *PageTableRoot;
@@ -1110,12 +1111,40 @@ InitializeSmmuDxe (
     goto Error;
   }
 
+  // Set SMMUs' Enabled status based on the SMMU_STATUS in the SMMU_CONFIG HOB structure.
+  for (SmmuStatusIndex = 0; i < SmmuConfig->SmmuCount; SmmuStatusIndex++) {
+    for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
+      if (mIoMmu->SmmuInfo[SmmuIndex].SmmuBase == SmmuConfig->SmmuStatus[SmmuStatusIndex].SmmuBase) {
+        mIoMmu->SmmuInfo[SmmuIndex].Enabled = SmmuConfig->SmmuStatus[SmmuStatusIndex].Enabled;
+      }
+    }
+  }
+
   // Configure SMMUv3 hardware
   for (SmmuIndex = 0; SmmuIndex < mIoMmu->SmmuCount; SmmuIndex++) {
     Status = SmmuV3Configure (&mIoMmu->SmmuInfo[SmmuIndex], PageTableRoot);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to configure SMMUv3 hardware\n", __func__));
       goto Error;
+    }
+  }
+
+  // Disable any SMMU that is not enabled in the SMMU_CONFIG HOB structure.
+  // Disables translation and sets global bypass.
+  for (SmmuStatusIndex = 0; i < SmmuConfig->SmmuCount; SmmuStatusIndex++) {
+    if (SmmuConfig->SmmuStatus[SmmuStatusIndex].Enabled == FALSE) {
+      Status = SmmuV3DisableTranslation (SmmuConfig->SmmuStatus[SmmuStatusIndex].SmmuBase);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: Failed to disable smmu translation.\n", __func__));
+        ASSERT_EFI_ERROR (Status);
+      }
+  
+      Status = SmmuV3SetGlobalBypass (SmmuConfig->SmmuStatus[SmmuStatusIndex].SmmuBase);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: Failed to set global bypass.\n", __func__));
+        ASSERT_EFI_ERROR (Status);
+      }
+      DEBUG ((DEBUG_INFO, "%a: SMMUv3 0x%llx is disabled\n", __func__, SmmuConfig->SmmuStatus[SmmuStatusIndex].SmmuBase));
     }
   }
 

--- a/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
+++ b/ArmPkg/Drivers/SmmuDxe/SmmuV3.h
@@ -178,6 +178,7 @@ typedef struct _SMMU_INFO {
   UINT32                      OutputAddressWidth;
   UINT8                       TranslationStartingLevel;
   BOOLEAN                     PageTableRootConcatenated;
+  BOOLEAN                     Enabled;
 } SMMU_INFO;
 
 // IoMmu configuration structure

--- a/ArmPkg/Include/Guid/SmmuConfig.h
+++ b/ArmPkg/Include/Guid/SmmuConfig.h
@@ -30,12 +30,19 @@
 
 #pragma pack(push, 1)
 
+typedef struct _SMMU_STATUS {
+  UINT64   SmmuBase;          // Base address of the SMMU registers
+  BOOLEAN  Enabled;           // TRUE if SMMU is enabled, FALSE otherwise
+} SMMU_STATUS;
+
 // SMMU_CONFIG structure to pass the SMMU configuration data from the platform to the SMMU driver.
 typedef struct _SMMU_CONFIG {
-  UINT32    VersionMajor;
-  UINT32    VersionMinor;
-  UINT32    IortSize;
-  UINT32    IortOffset;
+  UINT32       VersionMajor;
+  UINT32       VersionMinor;
+  UINT32       SmmuCount;
+  SMMU_STATUS  *SmmuStatus;
+  UINT32       IortSize;
+  UINT32       IortOffset;
 } SMMU_CONFIG;
 
 #pragma pack(pop)


### PR DESCRIPTION
## Description
Update to allow platform to enable/disable SMMUs

Allows the platform to toggle translation/bypass (enable/disable) on any SMMU within the IORT during pre-boot.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on qemu SBSA and physical arm platform.

## Integration Instructions

Same as before, pass in SMMU_CONFIG HOB structure to SmmuDxe